### PR TITLE
Add double quotes around output tfvars

### DIFF
--- a/az/az.go
+++ b/az/az.go
@@ -175,10 +175,10 @@ func (a Az) AssignContributorRole(clientId string) error {
 }
 
 func (a *Az) WriteCredentials(id, tenantId, clientId, clientSecret, credentialOutputFile string) error {
-	creds := fmt.Sprintf(`subscription_id = %s
-tenant_id = %s
-client_id = %s
-client_secret = %s
+	creds := fmt.Sprintf(`subscription_id = "%s"
+tenant_id = "%s"
+client_id = "%s"
+client_secret = "%s"
 `,
 		id,
 		tenantId,

--- a/az/az_test.go
+++ b/az/az_test.go
@@ -286,10 +286,10 @@ var _ = Describe("Az", func() {
 
 			bytes, err := ioutil.ReadFile(credentialOutputFile)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(bytes)).To(ContainSubstring("subscription_id = subscription-id"))
-			Expect(string(bytes)).To(ContainSubstring("tenant_id = tenant-id"))
-			Expect(string(bytes)).To(ContainSubstring("client_id = client-id"))
-			Expect(string(bytes)).To(ContainSubstring("client_secret = client-secret"))
+			Expect(string(bytes)).To(ContainSubstring("subscription_id = \"subscription-id\""))
+			Expect(string(bytes)).To(ContainSubstring("tenant_id = \"tenant-id\""))
+			Expect(string(bytes)).To(ContainSubstring("client_id = \"client-id\""))
+			Expect(string(bytes)).To(ContainSubstring("client_secret = \"client-secret\""))
 
 			Expect(logger.PrintlnCall.Receives.Message).To(Equal("Wrote credentials to some-credential-file."))
 		})


### PR DESCRIPTION
This avoids Terraform erroring out with a message about parsing the tfvars file